### PR TITLE
Add setup script for Rust and DuckDB installation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "elite-parser"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+duckdb = { version = "1.1", features = ["bundled"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokio = { version = "1.0", features = ["full"] }
+anyhow = "1.0"
+rayon = "1.10"
+indicatif = "0.17"
+
+[target.'cfg(windows)'.dependencies.windows]
+version = "0.52"
+features = [
+    "Win32_System_RestartManager",
+    "Win32_Foundation"
+]
+
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"
+opt-level = 3

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+echo "Installing Rust (if not already installed)..."
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+source $HOME/.cargo/env
+
+echo "⚡ Installing DuckDB CLI (optional, for manual queries)..."
+# For Windows with chocolatey
+# choco install duckdb
+
+# For Linux/WSL
+wget https://github.com/duckdb/duckdb/releases/latest/download/duckdb_cli-linux-amd64.zip
+unzip duckdb_cli-linux-amd64.zip
+sudo mv duckdb /usr/local/bin/
+
+echo "Building optimized release version..."
+cargo build --release
+
+echo "Ready to run! Execute with:"
+echo "cargo run --release"


### PR DESCRIPTION
This script installs Rust and DuckDB CLI, builds the project, and provides usage instructions.